### PR TITLE
Correct WIN32 deadlock

### DIFF
--- a/src/efsw/FileWatcherWin32.cpp
+++ b/src/efsw/FileWatcherWin32.cpp
@@ -99,7 +99,7 @@ void FileWatcherWin32::removeWatch(const std::string& directory)
 		if(directory == (*iter)->Watch->DirName)
 		{
 			removeWatch((*iter)->Watch->ID);
-			return;
+			break;
 		}
 	}
 


### PR DESCRIPTION
There is a deadlock on win32 in FileWatcherWin32 destructor...
